### PR TITLE
Use SQL as session database if the DB_URI is specified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ gTTS-token>=1.1.3
 psycopg2
 python-dotenv
 aiohttp
+git+https://github.com/tulir/telethon-session-sqlalchemy

--- a/userbot/__init__.py
+++ b/userbot/__init__.py
@@ -2,6 +2,17 @@ import sqlite3
 import subprocess
 import sys, os
 import dotenv
+from alchemysession import AlchemySessionContainer
+from argparse import ArgumentParser
+
+parser = ArgumentParser()
+
+parser.add_argument(
+    "-d", "--delete", help="Deletes the current session and creates a new one", action="store_true"
+)
+
+args = parser.parse_args()
+
 dotenv.load_dotenv("config.env")
 BUILD_CHOICE=os.environ.get("BUILD_CHOICE","stable")
 subprocess.run(["rm", "-rf", "brains.check"], stdout=subprocess.PIPE)
@@ -118,8 +129,19 @@ else:
         "Your config file seems to be un-edited. Doing so is not allowed. Bot exiting!"
     )
     quit(1)
+
+session = "userbot"
+
+if DB_URI:
+    container = AlchemySessionContainer(DB_URI)
+    session = container.new_session("userbot")
+    if args.delete:
+        session.delete()
+        print("SESSION DELETED...")
+
+
 if len(sys.argv) in (1,3,4):
-    bot = TelegramClient("userbot", API_KEY, API_HASH)
+    bot = TelegramClient(session, API_KEY, API_HASH)
 else:
     bot = TelegramClient(None, API_KEY, API_HASH)
     bot.session.set_dc(2, "149.154.167.40", 443)


### PR DESCRIPTION
Use SQL as session database if the DB_URI is specified. This will switch to a different session so reconnecting with the TG account is required as the old session will not be used. This will be only required just at the first start after using the new session.

The session can be deleted at any time using `python3 -m -d` or `python3 -m --delete`

The pro of this method is that there won't be any problems while using this userbot on heroku-like servers.

The old session will still be available for  users running in Non-SQL mode